### PR TITLE
Handle transparent pixels on resizePixel.

### DIFF
--- a/canvasquery.js
+++ b/canvasquery.js
@@ -662,8 +662,7 @@
       canvas.height = this.canvas.height * pixelSize | 0;
 
       for (var i = 0, len = sourcePixels.length; i < len; i += 4) {
-        if (!sourcePixels[i + 3]) continue;
-        context.fillStyle = $.rgbToHex(sourcePixels[i + 0], sourcePixels[i + 1], sourcePixels[i + 2]);
+        context.fillStyle = 'rgba('+sourcePixels[i + 0]+','+sourcePixels[i + 1]+','+sourcePixels[i + 2]+','+sourcePixels[i + 3]/255+')';
 
         var x = (i / 4) % this.canvas.width;
         var y = (i / 4) / this.canvas.width | 0;


### PR DESCRIPTION
I'm not sure if there was a reason transparency wasn't handled for resizePixel, but I'm using it on my project and thought I would push the change. This doesn't involve a change to the minified version.
