### PR TITLE
Semver requires a three-dot notation for versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "CanvasQuery",
-  "version": "1.0",
+  "version": "1.0.0",
   "description": "Canvas Query is a wrapper library for HTML5 Canvas element which allows it to be used with jQuery like syntax.",
   "keywords": [ "html5", "client-side", "canvas", "development" ],
   "main": "canvasquery.js",


### PR DESCRIPTION
As it stands, `npm install rezoner/CanvasQuery` fails with `npm ERR! Invalid version: "1.0"`